### PR TITLE
Docs/add env example and mongodb setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,45 +5,88 @@
 This project is a MERN stack website designed to track and display the overall statistical trends of champions from Wild Rift.
 
 Features include:
+
 * interactive tierlist table and champion page
-* Dynamic assignment of ranks and tiers depending on champion performance 
+* Dynamic assignment of ranks and tiers depending on champion performance
 * Comment section for each champion (account required to access)
 * A public backend API for all data used in this project
 
-Website Link: https://statswr.vercel.app
+Website Link: <https://statswr.vercel.app>
 
 ## Dev setup instructions
-> Tested with npm v10.2.4 Node v20.11.1 
 
-1. ```git clone``` the repository
-2. set up environment variables in the backend folder by creating a .env file and adding 
-   ```
-   CLIENT_URL = <your client url>
-   JWT_SECRET = (128 byte string)
-   MONGO_URI = (your mongodb URI)
+> Tested with npm v10.2.4 Node v20.11.1
 
-   PORT = 5555
+statsWR has three main local development components:
 
-   MCP_CLIENT_REFRESH_INTERVAL = 1500000 # 25 minutes
+* Frontend: Vite + React app in `frontend`
+* Backend: Express API in `backend`
+* Database: MongoDB, used by the backend for champion data, abilities, users, and comments
 
-   # required for chatbot
-   OPENAI_API_KEY = <your openai api key>
-   MCP_SERVER_URL = <your mcp server base url>/mcp/
+1. `git clone` the repository
+2. Copy the example environment files:
+
+   ```bash
+   cp backend/.env.example backend/.env
+   cp frontend/.env.example frontend/.env
    ```
-3. set up environment variables in the frontend folder by creating a .env file and adding 
+
+   The example values are ready for the default local setup:
+   - note that backend
+   - frontend: `http://localhost:5173`
+   - backend: `http://localhost:5555`
+   - MongoDB: `mongodb://localhost:27017/statswr`
+3. Start MongoDB locally, or update `backend/.env` with your MongoDB Atlas URI.
+   For local development with Docker see 'How to set up the database below'
+
+4. Install dependencies and run the backend:
+
+   ```bash
+   cd backend
+   npm install
+   npm run dev
    ```
-   VITE_SERVER_URL = <your server url>
+
+5. In another terminal, install dependencies and run the frontend:
+
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
    ```
-4. Run development backend server with ```cd backend```, ```npm install```, and ```npm run dev```
-5. Run development frontend server on another terminal with ```cd frontend```, ```npm install```, and ```npm run dev```
+
+The chatbot route also needs a real `OPENAI_API_KEY` and MCP server URL. The default `.env.example` values are enough to start the core frontend, backend, and database setup, but chatbot responses require those optional services to be configured.
 
 ## How to set up the database
-In the backend terminal 
-* Run ```node scripts/populateAbilities.js``` to populate abilities. (Make sure the dependencies within ~/webscraper/requirements.txt is installed on your machine)
-* Run ```node scripts/autoUpdate.js``` to upload the gameplay data within the rawChampionsData folder (can be updated)
-* Run ```node scripts/deleteAllGameplayDataByDate.js``` to delete all gameplayData entries with the date field equal to targetPatchDate
+
+* if using local mongodb instance, navigate to `./database/` directory
+
+```bash
+# create new local docker container for atlas
+docker-compose up -d
+# connect to the atalas server with mongosh. install mongosh if it isn't
+mongosh "mongodb://user:pass@localhost:27019/?directConnection=true"
+# create database named statswr
+use statswr
+exit
+```
+
+* to stop the container, in the `./database/` directory
+```bash
+docker compose down
+```
+
+
+MongoDB must be running before these scripts are used. The scripts read `backend/.env`, so confirm `MONGO_URI` points to your local Docker database or your MongoDB Atlas database.
+
+In the backend terminal:
+
+* Run `node scripts/populateAbilities.js` to populate abilities. (Make sure the dependencies within `webscraper/requirements.txt` are installed on your machine)
+* Run `node scripts/autoUpdate.js` to upload the gameplay data within the `rawChampionsData` folder (can be updated)
+* Run `node scripts/deleteAllGameplayDataByDate.js` to delete all gameplayData entries with the date field equal to targetPatchDate
 
 ## Known issues (Work In Progress)
+
 * Graph hover attribute sometimes not zeroing when moving cursor off of the graph
 * Components within the Champion page not rendering uniformly upon first render
 * Up to 50 seconds for backend to reconnect if server is inactive for more than 15 minutes
@@ -52,14 +95,17 @@ In the backend terminal
 * WIP: Graph on hover label for path
 
 ## Endpoints
-v1 backend API Documentation: https://statswr-api.onrender.com/api-docs (DM for cors access)
+
+v1 backend API Documentation: <https://statswr-api.onrender.com/api-docs> (DM for cors access)
 
 ## Testing
-Vitest + Jest + Selenium (DM for access) 
+
+Vitest + Jest + Selenium (DM for access)
 
 ## Find a bug?
+
 Before sending a PR, squash all your merges and file an issue first.
 
-Contact andyhhdi@gmail.com or huidihu@utexas.edu for any questions.
+Contact <andyhhdi@gmail.com> or <huidihu@utexas.edu> for any questions.
 
 **statsWR v1 - 7/9/2024**

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,11 @@
+CLIENT_URL=http://localhost:5173
+JWT_SECRET=80a26278335e931265b2dd9a67fc8d60 #local-development-jwt-secret-change-this-before-deploying
+MONGO_URI="mongodb://user:pass@localhost:27019/statswr?authSource=admin&directConnection=true"
+
+PORT=5555
+
+MCP_CLIENT_REFRESH_INTERVAL=1500000
+
+# Optional: required only for the authenticated chatbot route.
+OPENAI_API_KEY= api-key # <your openai api key>
+MCP_SERVER_URL=http://localhost:3001/mcp/

--- a/database/compose.yml
+++ b/database/compose.yml
@@ -1,0 +1,15 @@
+services:
+  mongodb:
+    hostname: mongodb
+    image: mongodb/mongodb-atlas-local
+    environment:
+      - MONGODB_INITDB_ROOT_USERNAME=user
+      - MONGODB_INITDB_ROOT_PASSWORD=pass
+    ports:
+      - 27019:27017
+    volumes:
+      - data:/data/db
+      - config:/data/configdb
+volumes:
+  data:
+  config:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_SERVER_URL=http://localhost:5555


### PR DESCRIPTION
- add instruction on how to setup local mongodb for statswr with docker
- add `.env.example` for both frontend and backend with immediately usable values
  - new contributors just need to copy the content to `.env`